### PR TITLE
change cheshire fw jump address to 0x9000000 (the default load address for seL4)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -350,6 +350,7 @@
             "PLATFORM_RISCV_ABI=lp64"
             "FW_DYNAMIC=y"
             "FW_JUMP=y"
+            "FW_JUMP_ADDR=0x90000000"
             "FW_PAYLOAD=y"
           ];
         })).override {


### PR DESCRIPTION
TODO: Changing a few other things.